### PR TITLE
Import DiscourseRoute rather than Discourse.Route (#1)

### DIFF
--- a/assets/javascripts/discourse/routes/admin-plugins-procourse-installer-index.js.es6
+++ b/assets/javascripts/discourse/routes/admin-plugins-procourse-installer-index.js.es6
@@ -1,4 +1,6 @@
-export default Discourse.Route.extend({
+import DiscourseRoute from "discourse/routes/discourse";
+
+export default DiscourseRoute.extend({
   model() {
     return {"plugin_url": ""};
   },


### PR DESCRIPTION
https://meta.discourse.org/t/procourse-installer-installing-removing-plugins-via-the-ui/115476/45?u=arkshine